### PR TITLE
feat: centralize backend API calls

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+const backendURL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:8000';
+
+export const api = axios.create({
+  baseURL: backendURL,
+});
+

--- a/frontend/src/data-form.js
+++ b/frontend/src/data-form.js
@@ -4,7 +4,7 @@ import {
     TextField,
     Button,
 } from '@mui/material';
-import axios from 'axios';
+import { api } from './api';
 
 const endpointMapping = {
     'Notion': 'notion',
@@ -19,7 +19,7 @@ export const DataForm = ({ integrationType, credentials }) => {
         try {
             const formData = new FormData();
             formData.append('credentials', JSON.stringify(credentials));
-            const response = await axios.post(`http://localhost:8000/integrations/${endpoint}/load`, formData);
+            const response = await api.post(`/integrations/${endpoint}/load`, formData);
             const data = response.data;
             setLoadedData(data);
         } catch (e) {

--- a/frontend/src/integrations/airtable.js
+++ b/frontend/src/integrations/airtable.js
@@ -6,7 +6,7 @@ import {
     Button,
     CircularProgress
 } from '@mui/material';
-import axios from 'axios';
+import { api } from '../api';
 
 export const AirtableIntegration = ({ user, org, integrationParams, setIntegrationParams }) => {
     const [isConnected, setIsConnected] = useState(false);
@@ -19,7 +19,7 @@ export const AirtableIntegration = ({ user, org, integrationParams, setIntegrati
             const formData = new FormData();
             formData.append('user_id', user);
             formData.append('org_id', org);
-            const response = await axios.post(`http://localhost:8000/integrations/airtable/authorize`, formData);
+            const response = await api.post(`/integrations/airtable/authorize`, formData);
             const authURL = response?.data;
 
             const newWindow = window.open(authURL, 'Airtable Authorization', 'width=600, height=600');
@@ -43,7 +43,7 @@ export const AirtableIntegration = ({ user, org, integrationParams, setIntegrati
             const formData = new FormData();
             formData.append('user_id', user);
             formData.append('org_id', org);
-            const response = await axios.post(`http://localhost:8000/integrations/airtable/credentials`, formData);
+            const response = await api.post(`/integrations/airtable/credentials`, formData);
             const credentials = response.data; 
             if (credentials) {
                 setIsConnecting(false);

--- a/frontend/src/integrations/notion.js
+++ b/frontend/src/integrations/notion.js
@@ -6,7 +6,7 @@ import {
     Button,
     CircularProgress
 } from '@mui/material';
-import axios from 'axios';
+import { api } from '../api';
 
 export const NotionIntegration = ({ user, org, integrationParams, setIntegrationParams }) => {
     const [isConnected, setIsConnected] = useState(false);
@@ -19,7 +19,7 @@ export const NotionIntegration = ({ user, org, integrationParams, setIntegration
             const formData = new FormData();
             formData.append('user_id', user);
             formData.append('org_id', org);
-            const response = await axios.post(`http://localhost:8000/integrations/notion/authorize`, formData);
+            const response = await api.post(`/integrations/notion/authorize`, formData);
             console.log(response);
             const authURL = response?.data;
 
@@ -44,7 +44,7 @@ export const NotionIntegration = ({ user, org, integrationParams, setIntegration
             const formData = new FormData();
             formData.append('user_id', user);
             formData.append('org_id', org);
-            const response = await axios.post(`http://localhost:8000/integrations/notion/credentials`, formData);
+            const response = await api.post(`/integrations/notion/credentials`, formData);
             const credentials = response.data; 
             if (credentials) {
                 setIsConnecting(false);


### PR DESCRIPTION
## Summary
- create reusable axios client with configurable backend URL
- refactor integration components to use the shared client

## Testing
- `pytest`
- `CI=true npm test --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6895928258d88324b5bcc527d60d5cf6