### PR TITLE
Allow frontend 3001 origin and handle missing Redis

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ app = FastAPI()
 
 origins = [
     "http://localhost:3000",  # React app address
+    "http://localhost:3001",  # Alternate frontend port
 ]
 
 app.add_middleware(

--- a/backend/redis_client.py
+++ b/backend/redis_client.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import redis.asyncio as redis
 from kombu.utils.url import safequote
@@ -5,13 +6,34 @@ from kombu.utils.url import safequote
 redis_host = safequote(os.environ.get('REDIS_HOST', 'localhost'))
 redis_client = redis.Redis(host=redis_host, port=6379, db=0)
 
-async def add_key_value_redis(key, value, expire=None):
-    await redis_client.set(key, value)
-    if expire:
-        await redis_client.expire(key, expire)
+# In-memory fallback if Redis is unavailable
+_local_store: dict[str, str] = {}
+
+
+async def add_key_value_redis(key, value, expire: int | None = None):
+    """Store a value in Redis or fall back to local memory."""
+    try:
+        await redis_client.set(key, value)
+        if expire:
+            await redis_client.expire(key, expire)
+    except redis.exceptions.ConnectionError:
+        _local_store[key] = value
+        if expire:
+            loop = asyncio.get_running_loop()
+            loop.call_later(expire, _local_store.pop, key, None)
+
 
 async def get_value_redis(key):
-    return await redis_client.get(key)
+    """Retrieve a value from Redis or local memory."""
+    try:
+        return await redis_client.get(key)
+    except redis.exceptions.ConnectionError:
+        return _local_store.get(key)
+
 
 async def delete_key_redis(key):
-    await redis_client.delete(key)
+    """Remove a key from Redis or local memory."""
+    try:
+        await redis_client.delete(key)
+    except redis.exceptions.ConnectionError:
+        _local_store.pop(key, None)


### PR DESCRIPTION
## Summary
- allow FastAPI backend to accept requests from http://localhost:3001 for CORS
- fall back to an in-memory store when Redis isn't running to avoid connection errors

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689594cc39d48324a730694876d58df1