### PR TITLE
Handle OAuth popup without polling

### DIFF
--- a/frontend/src/integrations/airtable.js
+++ b/frontend/src/integrations/airtable.js
@@ -22,15 +22,12 @@ export const AirtableIntegration = ({ user, org, integrationParams, setIntegrati
             const response = await api.post(`/integrations/airtable/authorize`, formData);
             const authURL = response?.data;
 
-            const newWindow = window.open(authURL, 'Airtable Authorization', 'width=600, height=600');
-
-            // Polling for the window to close
-            const pollTimer = window.setInterval(() => {
-                if (newWindow?.closed !== false) { 
-                    window.clearInterval(pollTimer);
-                    handleWindowClosed();
-                }
-            }, 200);
+            const onFocus = () => {
+                window.removeEventListener('focus', onFocus);
+                setTimeout(() => handleWindowClosed(), 500);
+            };
+            window.addEventListener('focus', onFocus);
+            window.open(authURL, 'Airtable Authorization', 'width=600,height=600');
         } catch (e) {
             setIsConnecting(false);
             alert(e?.response?.data?.detail);

--- a/frontend/src/integrations/notion.js
+++ b/frontend/src/integrations/notion.js
@@ -20,18 +20,14 @@ export const NotionIntegration = ({ user, org, integrationParams, setIntegration
             formData.append('user_id', user);
             formData.append('org_id', org);
             const response = await api.post(`/integrations/notion/authorize`, formData);
-            console.log(response);
             const authURL = response?.data;
 
-            const newWindow = window.open(authURL, 'Notion Authorization', 'width=600, height=600');
-
-            // Polling for the window to close
-            const pollTimer = window.setInterval(() => {
-                if (newWindow?.closed !== false) { 
-                    window.clearInterval(pollTimer);
-                    handleWindowClosed();
-                }
-            }, 200);
+            const onFocus = () => {
+                window.removeEventListener('focus', onFocus);
+                setTimeout(() => handleWindowClosed(), 500);
+            };
+            window.addEventListener('focus', onFocus);
+            window.open(authURL, 'Notion Authorization', 'width=600,height=600');
         } catch (e) {
             setIsConnecting(false);
             alert(e?.response?.data?.detail);


### PR DESCRIPTION
## Summary
- eliminate Cross-Origin-Opener-Policy warnings by using focus listeners for OAuth popups
- delay credential fetch until popup closes to avoid premature 400 responses

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68959bb6a0008324be4bb298deb1ff36