### PR TITLE
Use environment variables for OAuth client credentials

### DIFF
--- a/backend/integrations/airtable.py
+++ b/backend/integrations/airtable.py
@@ -9,18 +9,24 @@ import httpx
 import asyncio
 import base64
 import hashlib
+import os
+from urllib.parse import quote
 
 import requests
 from integrations.integration_item import IntegrationItem
 
 from redis_client import add_key_value_redis, get_value_redis, delete_key_redis
 
-# CLIENT_ID = 'XXX'
-# CLIENT_SECRET = 'XXX'
-CLIENT_ID = '329147ef-ac8b-4863-bced-77b7b195258f'
-CLIENT_SECRET = 'e59aec7edddef2edf4388ef611b151ab5fc85c61f828df909c147085e8ffb4f1'
+CLIENT_ID = os.getenv('AIRTABLE_CLIENT_ID')
+CLIENT_SECRET = os.getenv('AIRTABLE_CLIENT_SECRET')
+if not CLIENT_ID or not CLIENT_SECRET:
+    raise ValueError('Missing Airtable client ID or secret.')
+
 REDIRECT_URI = 'http://localhost:8000/integrations/airtable/oauth2callback'
-authorization_url = f'https://airtable.com/oauth2/v1/authorize?client_id={CLIENT_ID}&response_type=code&owner=user&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fintegrations%2Fairtable%2Foauth2callback'
+authorization_url = (
+    f'https://airtable.com/oauth2/v1/authorize?client_id={CLIENT_ID}'
+    f'&response_type=code&owner=user&redirect_uri={quote(REDIRECT_URI)}'
+)
 
 encoded_client_id_secret = base64.b64encode(f'{CLIENT_ID}:{CLIENT_SECRET}'.encode()).decode()
 scope = 'data.records:read data.records:write data.recordComments:read data.recordComments:write schema.bases:read schema.bases:write'

--- a/backend/integrations/notion.py
+++ b/backend/integrations/notion.py
@@ -9,12 +9,15 @@ import asyncio
 import base64
 import requests
 from urllib.parse import quote, unquote
+import os
 from integrations.integration_item import IntegrationItem
 
 from redis_client import add_key_value_redis, get_value_redis, delete_key_redis
 
-CLIENT_ID = 'XXX'
-CLIENT_SECRET = 'XXX'
+CLIENT_ID = os.getenv('NOTION_CLIENT_ID')
+CLIENT_SECRET = os.getenv('NOTION_CLIENT_SECRET')
+if not CLIENT_ID or not CLIENT_SECRET:
+    raise ValueError('Missing Notion client ID or secret.')
 encoded_client_id_secret = base64.b64encode(f'{CLIENT_ID}:{CLIENT_SECRET}'.encode()).decode()
 
 REDIRECT_URI = 'http://localhost:8000/integrations/notion/oauth2callback'


### PR DESCRIPTION
## Summary
- Load Airtable client ID and secret from `AIRTABLE_CLIENT_ID` and `AIRTABLE_CLIENT_SECRET`
- Load Notion client ID and secret from `NOTION_CLIENT_ID` and `NOTION_CLIENT_SECRET`
- Raise clear errors when required environment variables are missing

## Testing
- `python -m py_compile backend/integrations/airtable.py backend/integrations/notion.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895e17f7a748324bb5cff1fcd98a298