### PR TITLE
Load env vars for Airtable and Notion

### DIFF
--- a/backend/integrations/airtable.py
+++ b/backend/integrations/airtable.py
@@ -13,16 +13,23 @@ import os
 from urllib.parse import quote
 
 import requests
+from dotenv import load_dotenv
 from integrations.integration_item import IntegrationItem
 
 from redis_client import add_key_value_redis, get_value_redis, delete_key_redis
+
+# Load environment variables from a .env file if present
+load_dotenv()
 
 CLIENT_ID = os.getenv('AIRTABLE_CLIENT_ID')
 CLIENT_SECRET = os.getenv('AIRTABLE_CLIENT_SECRET')
 if not CLIENT_ID or not CLIENT_SECRET:
     raise ValueError('Missing Airtable client ID or secret.')
 
-REDIRECT_URI = 'http://localhost:8000/integrations/airtable/oauth2callback'
+REDIRECT_URI = os.getenv(
+    'AIRTABLE_REDIRECT_URI',
+    'http://localhost:8000/integrations/airtable/oauth2callback',
+)
 authorization_url = (
     f'https://airtable.com/oauth2/v1/authorize?client_id={CLIENT_ID}'
     f'&response_type=code&owner=user&redirect_uri={quote(REDIRECT_URI)}'

--- a/backend/integrations/notion.py
+++ b/backend/integrations/notion.py
@@ -10,9 +10,13 @@ import base64
 import requests
 from urllib.parse import quote, unquote
 import os
+from dotenv import load_dotenv
 from integrations.integration_item import IntegrationItem
 
 from redis_client import add_key_value_redis, get_value_redis, delete_key_redis
+
+# Load environment variables from a .env file if present
+load_dotenv()
 
 CLIENT_ID = os.getenv('NOTION_CLIENT_ID')
 CLIENT_SECRET = os.getenv('NOTION_CLIENT_SECRET')
@@ -20,7 +24,10 @@ if not CLIENT_ID or not CLIENT_SECRET:
     raise ValueError('Missing Notion client ID or secret.')
 encoded_client_id_secret = base64.b64encode(f'{CLIENT_ID}:{CLIENT_SECRET}'.encode()).decode()
 
-REDIRECT_URI = 'http://localhost:8000/integrations/notion/oauth2callback'
+REDIRECT_URI = os.getenv(
+    'NOTION_REDIRECT_URI',
+    'http://localhost:8000/integrations/notion/oauth2callback',
+)
 # Build the authorization URL with an encoded redirect URI. Using `quote`
 # avoids hardcoding a percent-encoded value and prevents malformed URLs.
 authorization_url = (


### PR DESCRIPTION
## Summary
- load environment variables from .env for Airtable and Notion integrations
- allow overriding redirect URIs via env vars

## Testing
- `AIRTABLE_CLIENT_ID=foo AIRTABLE_CLIENT_SECRET=bar NOTION_CLIENT_ID=baz NOTION_CLIENT_SECRET=qux python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68961186cf4483248b7d5639253ab0d9